### PR TITLE
Refactor RustFS bootstrap and orchestrator flow

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,23 @@
+# src layout
+
+This directory uses an orchestrator-first layout.
+
+- `main.py`: Thin orchestrator for execution flow only.
+- `core/`: Shared infrastructure clients (e.g., RustFS client).
+- `catalog/`: Iceberg catalog and table management.
+- `pipeline/`: Reusable pipeline steps.
+  - `bootstrap/`: Environment/bootstrap steps.
+  - `ingestion/`: Data ingestion steps.
+  - `scraper/`: Data collection components.
+- `utility/`: Reusable transformation/helper functions.
+- `Jupyter/`: Exploration and validation notebooks.
+- `others/`: Legacy scripts under migration to reusable modules.
+- `dbt101/`: Learning assets and examples.
+
+## refactor rule
+
+When adding a new processing step:
+
+1. Create a reusable module in `pipeline/` (or `core/` when infra-related).
+2. Keep side effects inside callable functions.
+3. Wire execution from `main.py` as orchestrator.

--- a/src/core/storage_client.py
+++ b/src/core/storage_client.py
@@ -1,11 +1,11 @@
 import logging
 import os
+from dataclasses import dataclass
 
 import boto3
+from botocore.client import BaseClient
 from botocore.config import Config
-from dotenv import load_dotenv
-
-load_dotenv()
+from botocore.exceptions import ClientError
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
@@ -13,35 +13,61 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class RustFSConfig:
+    endpoint_url: str
+    access_key: str
+    secret_key: str
+    region: str = "us-east-1"
+
+    @classmethod
+    def from_env(cls) -> "RustFSConfig":
+        endpoint_url = os.environ.get("AWS_ENDPOINT_URL", "").strip()
+        access_key = os.environ.get("AWS_ACCESS_KEY_ID", "").strip()
+        secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "").strip()
+        region = os.environ.get("AWS_REGION", "us-east-1").strip()
+
+        if not endpoint_url:
+            raise ValueError("AWS_ENDPOINT_URL is not set.")
+        if not access_key or not secret_key:
+            raise ValueError("AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY is not set.")
+
+        return cls(
+            endpoint_url=endpoint_url,
+            access_key=access_key,
+            secret_key=secret_key,
+            region=region,
+        )
+
+
 class RustFSClient:
-    def __init__(self):
-        self.endpoint_url = os.environ.get("AWS_ENDPOINT_URL")
-        self.access_key = os.environ.get("AWS_ACCESS_KEY_ID")
-        self.secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
-        self.region = os.environ.get("AWS_REGION")
-
-        if not self.access_key or not self.secret_key:
-            raise ValueError("RUSTFS_ACCESS_KEY or RUSTFS_SECRET_KEY is not set.")
-
-        self.s3 = boto3.client(
+    def __init__(
+        self,
+        config: RustFSConfig | None = None,
+        s3_client: BaseClient | None = None,
+    ):
+        self.config = config or RustFSConfig.from_env()
+        self.s3 = s3_client or boto3.client(
             "s3",
-            endpoint_url=self.endpoint_url,
-            aws_access_key_id=self.access_key,
-            aws_secret_access_key=self.secret_key,
+            endpoint_url=self.config.endpoint_url,
+            aws_access_key_id=self.config.access_key,
+            aws_secret_access_key=self.config.secret_key,
             config=Config(signature_version="s3v4"),
-            region_name=self.region,
+            region_name=self.config.region,
         )
 
     def get_storage_options(self):
         """外部ライブラリ(Polars等)に渡すためのS3接続設定を辞書で返す"""
         return {
-            "key": self.access_key,
-            "secret": self.secret_key,
-            "endpoint_url": self.endpoint_url,
-            "client_kwargs": {"region_name": self.region},
+            "key": self.config.access_key,
+            "secret": self.config.secret_key,
+            "endpoint_url": self.config.endpoint_url,
+            "client_kwargs": {"region_name": self.config.region},
         }
 
-    def upload_file(self, bucket_name, file_path, object_name=None):
+    def upload_file(
+        self, bucket_name: str, file_path: str, object_name: str | None = None
+    ) -> None:
         if object_name is None:
             object_name = os.path.basename(file_path)
 
@@ -52,7 +78,7 @@ class RustFSClient:
             logger.error(f"Error uploading file: {e}")
             raise
 
-    def download_file(self, bucket_name, object_name, file_path):
+    def download_file(self, bucket_name: str, object_name: str, file_path: str) -> None:
         try:
             self.s3.download_file(bucket_name, object_name, file_path)
             logger.info(
@@ -62,7 +88,7 @@ class RustFSClient:
             logger.error(f"Error downloading file: {e}")
             raise
 
-    def list_files(self, bucket_name, prefix=""):
+    def list_files(self, bucket_name: str, prefix: str = "") -> list[str]:
         try:
             response = self.s3.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
             files = [obj["Key"] for obj in response.get("Contents", [])]
@@ -72,7 +98,7 @@ class RustFSClient:
             logger.error(f"Error listing files: {e}")
             raise
 
-    def delete_file(self, bucket_name, object_name):
+    def delete_file(self, bucket_name: str, object_name: str) -> None:
         try:
             self.s3.delete_object(Bucket=bucket_name, Key=object_name)
             logger.info(f"File {object_name} deleted from {bucket_name}")
@@ -120,19 +146,122 @@ class RustFSClient:
             logger.error(f"Error deleting folder '{prefix}': {e}")
             raise
 
-    def create_bucket(self, bucket_name):
+    def create_bucket(
+        self, bucket_name: str, object_lock_enabled: bool = False
+    ) -> None:
         try:
-            self.s3.create_bucket(Bucket=bucket_name)
+            params: dict[str, str | bool] = {"Bucket": bucket_name}
+            if object_lock_enabled:
+                params["ObjectLockEnabledForBucket"] = True
+
+            self.s3.create_bucket(**params)
             logger.info(f"Bucket {bucket_name} created")
         except Exception as e:
             logger.error(f"Error creating bucket: {e}")
             raise
 
-    def get_object(self, bucket_name, object_name):
+    def bucket_exists(self, bucket_name: str) -> bool:
+        try:
+            self.s3.head_bucket(Bucket=bucket_name)
+            return True
+        except ClientError as error:
+            error_code = error.response.get("Error", {}).get("Code", "")
+            if error_code in {"404", "NoSuchBucket", "NotFound"}:
+                return False
+
+            logger.error(f"Error checking bucket existence: {error}")
+            raise
+
+    def ensure_bucket(
+        self, bucket_name: str, object_lock_enabled: bool = False
+    ) -> bool:
+        if self.bucket_exists(bucket_name):
+            logger.info(f"Bucket {bucket_name} already exists")
+            return False
+
+        self.create_bucket(bucket_name, object_lock_enabled=object_lock_enabled)
+        return True
+
+    def ensure_prefixes(self, bucket_name: str, prefixes: list[str]) -> None:
+        for prefix in prefixes:
+            normalized = prefix if prefix.endswith("/") else f"{prefix}/"
+            self.s3.put_object(Bucket=bucket_name, Key=normalized, Body=b"")
+            logger.info(f"Ensured prefix s3://{bucket_name}/{normalized}")
+
+    def set_default_object_lock_retention(
+        self, bucket_name: str, mode: str, days: int
+    ) -> None:
+        if mode not in {"COMPLIANCE", "GOVERNANCE"}:
+            raise ValueError("mode must be COMPLIANCE or GOVERNANCE")
+        if days <= 0:
+            raise ValueError("days must be greater than 0")
+
+        if not self.bucket_supports_object_lock(bucket_name):
+            raise RuntimeError(
+                "Bucket does not support Object Lock. "
+                "Create the bucket with ObjectLockEnabledForBucket=True first."
+            )
+
+        self.s3.put_object_lock_configuration(
+            Bucket=bucket_name,
+            ObjectLockConfiguration={
+                "ObjectLockEnabled": "Enabled",
+                "Rule": {
+                    "DefaultRetention": {
+                        "Mode": mode,
+                        "Days": days,
+                    }
+                },
+            },
+        )
+        logger.info(
+            "Set default object lock retention for %s: mode=%s, days=%s",
+            bucket_name,
+            mode,
+            days,
+        )
+
+    def bucket_supports_object_lock(self, bucket_name: str) -> bool:
+        try:
+            response = self.s3.get_object_lock_configuration(Bucket=bucket_name)
+            configuration = response.get("ObjectLockConfiguration", {})
+            return configuration.get("ObjectLockEnabled") == "Enabled"
+        except ClientError as error:
+            error_code = error.response.get("Error", {}).get("Code", "")
+            if error_code in {
+                "ObjectLockConfigurationNotFoundError",
+                "InvalidBucketState",
+                "InvalidRequest",
+            }:
+                return False
+            raise
+
+    def clear_default_object_lock_retention(self, bucket_name: str) -> bool:
+        if not self.bucket_supports_object_lock(bucket_name):
+            logger.info(
+                "Skip clearing object lock retention for %s because object lock is "
+                "disabled",
+                bucket_name,
+            )
+            return False
+
+        self.s3.put_object_lock_configuration(
+            Bucket=bucket_name,
+            ObjectLockConfiguration={"ObjectLockEnabled": "Enabled"},
+        )
+        logger.info("Cleared default object lock retention for %s", bucket_name)
+        return True
+
+    def get_object(self, bucket_name: str, object_name: str) -> bytes:
         try:
             response = self.s3.get_object(Bucket=bucket_name, Key=object_name)
             logger.info(f"Object {object_name} retrieved from {bucket_name}")
-            return response["Body"].read()
+            body = response.get("Body")
+            if body is None:
+                raise ValueError(
+                    f"Body is empty for object: {bucket_name}/{object_name}"
+                )
+            return body.read()
         except Exception as e:
             logger.error(f"Error getting object: {e}")
             raise

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,60 @@
+import argparse
+import logging
+
 from core.storage_client import RustFSClient
+from pipeline.bootstrap.rustfs_bootstrap import BucketPlan, apply_bucket_plans
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+DEFAULT_PREFIXES = ("raw", "bronze", "silver", "gold", "sandbox")
+DEFAULT_BUCKET_PLANS = [
+    BucketPlan(
+        name="jp-power-grid-dev",
+        prefixes=DEFAULT_PREFIXES,
+        retention_days=None,
+    ),
+    BucketPlan(
+        name="jp-power-grid-prd",
+        prefixes=DEFAULT_PREFIXES,
+        retention_days=7,
+        retention_mode="COMPLIANCE",
+    ),
+]
 
 
 def main():
+    parser = argparse.ArgumentParser(description="RustFS bucket bootstrap orchestrator")
+    parser.add_argument(
+        "--bucket",
+        action="append",
+        dest="buckets",
+        help="Bucket name to initialize. Default is dev/prd plans.",
+    )
+    args = parser.parse_args()
+
     rustfs = RustFSClient()
-    rustfs.delete_folder("jp-power-grid-dev", "bronze/jepx_spot_price/")
+    if args.buckets:
+        target_set = set(args.buckets)
+        known_names = {plan.name for plan in DEFAULT_BUCKET_PLANS}
+        unknown_names = sorted(target_set - known_names)
+        if unknown_names:
+            parser.error(f"Unknown bucket names: {', '.join(unknown_names)}")
+
+        selected_plans = [
+            plan for plan in DEFAULT_BUCKET_PLANS if plan.name in target_set
+        ]
+    else:
+        selected_plans = DEFAULT_BUCKET_PLANS
+
+    created, existing = apply_bucket_plans(rustfs, selected_plans)
+
+    if created:
+        logger.info(f"Created buckets: {created}")
+    if existing:
+        logger.info(f"Existing buckets: {existing}")
 
 
 if __name__ == "__main__":

--- a/src/pipeline/bootstrap/rustfs_bootstrap.py
+++ b/src/pipeline/bootstrap/rustfs_bootstrap.py
@@ -1,0 +1,62 @@
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from core.storage_client import RustFSClient
+
+
+@dataclass(frozen=True)
+class BucketPlan:
+    name: str
+    prefixes: tuple[str, ...]
+    retention_days: int | None = None
+    retention_mode: str = "COMPLIANCE"
+
+
+def ensure_buckets(
+    client: RustFSClient, bucket_names: Iterable[str]
+) -> tuple[list[str], list[str]]:
+    """Ensure required buckets exist and return (created, already_existing)."""
+    created: list[str] = []
+    existing: list[str] = []
+
+    for bucket_name in bucket_names:
+        if client.ensure_bucket(bucket_name):
+            created.append(bucket_name)
+        else:
+            existing.append(bucket_name)
+
+    return created, existing
+
+
+def apply_bucket_plan(client: RustFSClient, plan: BucketPlan) -> bool:
+    created = client.ensure_bucket(
+        plan.name,
+        object_lock_enabled=plan.retention_days is not None,
+    )
+    client.ensure_prefixes(plan.name, list(plan.prefixes))
+
+    if plan.retention_days is None:
+        client.clear_default_object_lock_retention(plan.name)
+    else:
+        client.set_default_object_lock_retention(
+            bucket_name=plan.name,
+            mode=plan.retention_mode,
+            days=plan.retention_days,
+        )
+
+    return created
+
+
+def apply_bucket_plans(
+    client: RustFSClient, plans: Iterable[BucketPlan]
+) -> tuple[list[str], list[str]]:
+    created: list[str] = []
+    existing: list[str] = []
+
+    for plan in plans:
+        if apply_bucket_plan(client, plan):
+            created.append(plan.name)
+        else:
+            existing.append(plan.name)
+
+    return created, existing

--- a/src/pipeline/ingestion/ingest_jepx.py
+++ b/src/pipeline/ingestion/ingest_jepx.py
@@ -1,7 +1,11 @@
 import io
 import logging
+import sys
+from pathlib import Path
 
 import polars as pl
+
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
 from catalog.manage_iceberg import get_catalog
 from core.storage_client import RustFSClient
@@ -13,47 +17,55 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-container = RustFSClient()
-logger.info("RustFSClient initialized successfully.")
+SCHEMA_PATH = "/workspace/data/schema/bronze/jepx_spot_price.csv"
 
-bucket_name = "jp-power-grid-dev"
-object_key = "raw/jepx/spot_summary/spot_summary_2026.csv"
 
-SCHEMA_PATH = r"/workspace/data/schema/bronze/jepx_spot_price.csv"
-
-try:
-    print(f"Fetching s3://{bucket_name}/{object_key}...")
-    response = container.get_object(bucket_name=bucket_name, object_name=object_key)
+def ingest_jepx_spot_summary(
+    client: RustFSClient,
+    bucket_name: str,
+    object_key: str,
+    source_file_name: str,
+    catalog_name: str = "dlh_dev",
+    table_identifier: str = "bronze.jepx_spot_price",
+    schema_path: str = SCHEMA_PATH,
+) -> int:
+    logger.info(f"Fetching s3://{bucket_name}/{object_key}...")
+    response = client.get_object(bucket_name=bucket_name, object_name=object_key)
 
     csv_string_io = io.StringIO(response.decode("cp932"))
     raw_df = pl.read_csv(csv_string_io, infer_schema_length=0)
 
-    print(f"Successfully loaded {len(raw_df)} rows as raw strings.")
-
-    select_exprs = build_schema_exprs(SCHEMA_PATH)
+    select_exprs = build_schema_exprs(schema_path)
     cast_df = raw_df.select(select_exprs)
 
     cast_df = cast_df.with_columns(
-        pl.lit("spot_summary_2026.csv").alias("source_data"),
+        pl.lit(source_file_name).alias("source_data"),
         pl.lit("new").alias("status"),
     )
-
     df_with_metadata = add_metadata(cast_df)
 
-    print(df_with_metadata.head())
-
-    catalog = get_catalog("dlh_dev")
-    table = catalog.load_table("bronze.jepx_spot_price")
-
+    catalog = get_catalog(catalog_name)
+    table = catalog.load_table(table_identifier)
     target_schema = table.schema().as_arrow()
 
     arrow_table = df_with_metadata.to_arrow()
     casted_arrow_table = arrow_table.cast(target_schema)
-
     table.append(casted_arrow_table)
 
-    print(f"Successfully ingested {len(df_with_metadata)} rows into the iceberg table.")
+    row_count = len(df_with_metadata)
+    logger.info(f"Successfully ingested {row_count} rows into {table_identifier}.")
+    return row_count
 
-except Exception as e:
-    logger.error(f"Error fetching object: {e}")
-    raise
+
+def main() -> None:
+    client = RustFSClient()
+    ingest_jepx_spot_summary(
+        client=client,
+        bucket_name="jp-power-grid-dev",
+        object_key="raw/jepx/spot_summary/spot_summary_2026.csv",
+        source_file_name="spot_summary_2026.csv",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pipeline/ingestion/upload_raw.py
+++ b/src/pipeline/ingestion/upload_raw.py
@@ -13,6 +13,24 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def upload_raw_file(
+    client: RustFSClient,
+    file_path: str,
+    bucket_name: str,
+    object_key: str,
+) -> None:
+    if not Path(file_path).exists():
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    logger.info(f"Uploading {file_path} to s3://{bucket_name}/{object_key}...")
+    client.upload_file(
+        bucket_name=bucket_name,
+        file_path=file_path,
+        object_name=object_key,
+    )
+    logger.info("Upload completed successfully.")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Script to upload local CSV files to RustFS (raw layer)"
@@ -33,21 +51,14 @@ def main():
 
     args = parser.parse_args()
 
-    if not Path(args.file).exists():
-        logger.error(f"File not found: {args.file}")
-        sys.exit(1)
-
-    logger.info("Starting upload process...")
-
     try:
         client = RustFSClient()
-
-        logger.info(f"Uploading {args.file} to s3://{args.bucket}/{args.key}...")
-        client.upload_file(
-            bucket_name=args.bucket, file_path=args.file, object_name=args.key
+        upload_raw_file(
+            client=client,
+            file_path=args.file,
+            bucket_name=args.bucket,
+            object_key=args.key,
         )
-
-        logger.info("Upload completed successfully.")
     except Exception as e:
         logger.error(f"Upload failed: {e}")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- refactor RustFS storage client for DI-friendly initialization and safer bucket policy handling
- add reusable bootstrap module for bucket plans (dev/prd), prefixes, and retention policy setup
- keep main.py as a thin orchestrator and wire bootstrap execution flow
- convert ingestion scripts to reusable function-oriented structure and keep entrypoints thin
- add src layout guidance document

## Validation
- uv run ruff check src/core/storage_client.py src/main.py src/pipeline/bootstrap/rustfs_bootstrap.py src/pipeline/ingestion/upload_raw.py src/pipeline/ingestion/ingest_jepx.py
- uv run python src/main.py