### PR TITLE
Add reusable JEPX scrape pipeline to RustFS raw

### DIFF
--- a/src/core/storage_client.py
+++ b/src/core/storage_client.py
@@ -78,6 +78,28 @@ class RustFSClient:
             logger.error(f"Error uploading file: {e}")
             raise
 
+    def upload_bytes(
+        self,
+        bucket_name: str,
+        object_name: str,
+        body: bytes,
+        content_type: str | None = None,
+    ) -> None:
+        params: dict[str, str | bytes] = {
+            "Bucket": bucket_name,
+            "Key": object_name,
+            "Body": body,
+        }
+        if content_type:
+            params["ContentType"] = content_type
+
+        try:
+            self.s3.put_object(**params)
+            logger.info(f"Uploaded bytes to {bucket_name}/{object_name}")
+        except Exception as e:
+            logger.error(f"Error uploading bytes: {e}")
+            raise
+
     def download_file(self, bucket_name: str, object_name: str, file_path: str) -> None:
         try:
             self.s3.download_file(bucket_name, object_name, file_path)

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,11 @@
 import argparse
 import logging
+from datetime import UTC, datetime
 
 from core.storage_client import RustFSClient
 from pipeline.bootstrap.rustfs_bootstrap import BucketPlan, apply_bucket_plans
+from pipeline.scraper.jepx_to_rustfs import scrape_jepx_to_rustfs
+from pipeline.scraper.module.jepx import JEPXSpotSummaryScraper
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
@@ -26,35 +29,93 @@ DEFAULT_BUCKET_PLANS = [
 
 
 def main():
-    parser = argparse.ArgumentParser(description="RustFS bucket bootstrap orchestrator")
-    parser.add_argument(
+    parser = argparse.ArgumentParser(description="Data platform orchestrator")
+    subparsers = parser.add_subparsers(dest="command")
+
+    bootstrap_parser = subparsers.add_parser(
+        "bootstrap-storage",
+        help="Create and configure RustFS buckets",
+    )
+    bootstrap_parser.add_argument(
         "--bucket",
         action="append",
         dest="buckets",
         help="Bucket name to initialize. Default is dev/prd plans.",
     )
+
+    jepx_parser = subparsers.add_parser(
+        "scrape-jepx",
+        help="Scrape JEPX spot summary and upload to RustFS raw layer",
+    )
+    jepx_parser.add_argument(
+        "--bucket",
+        default="jp-power-grid-dev",
+        help="Target bucket name (default: jp-power-grid-dev)",
+    )
+    jepx_parser.add_argument(
+        "--timestamp-ms",
+        type=int,
+        help="Optional UNIX timestamp in milliseconds for the JEPX request",
+    )
+
     args = parser.parse_args()
 
-    rustfs = RustFSClient()
-    if args.buckets:
-        target_set = set(args.buckets)
-        known_names = {plan.name for plan in DEFAULT_BUCKET_PLANS}
-        unknown_names = sorted(target_set - known_names)
-        if unknown_names:
-            parser.error(f"Unknown bucket names: {', '.join(unknown_names)}")
+    if args.command in {None, "bootstrap-storage"}:
+        rustfs = RustFSClient()
+        if args.command is None:
+            logger.info(
+                "No command was provided. Running bootstrap-storage for compatibility."
+            )
 
-        selected_plans = [
-            plan for plan in DEFAULT_BUCKET_PLANS if plan.name in target_set
-        ]
-    else:
-        selected_plans = DEFAULT_BUCKET_PLANS
+        buckets = getattr(args, "buckets", None)
+        if buckets:
+            target_set = set(buckets)
+            known_names = {plan.name for plan in DEFAULT_BUCKET_PLANS}
+            unknown_names = sorted(target_set - known_names)
+            if unknown_names:
+                parser.error(f"Unknown bucket names: {', '.join(unknown_names)}")
 
-    created, existing = apply_bucket_plans(rustfs, selected_plans)
+            selected_plans = [
+                plan for plan in DEFAULT_BUCKET_PLANS if plan.name in target_set
+            ]
+        else:
+            selected_plans = DEFAULT_BUCKET_PLANS
 
-    if created:
-        logger.info(f"Created buckets: {created}")
-    if existing:
-        logger.info(f"Existing buckets: {existing}")
+        created, existing = apply_bucket_plans(rustfs, selected_plans)
+
+        if created:
+            logger.info(f"Created buckets: {created}")
+        if existing:
+            logger.info(f"Existing buckets: {existing}")
+        return
+
+    if args.command == "scrape-jepx":
+        rustfs = RustFSClient()
+        scraper = JEPXSpotSummaryScraper()
+
+        if args.timestamp_ms:
+            target_at = datetime.fromtimestamp(
+                args.timestamp_ms / 1000,
+                tz=UTC,
+            )
+        else:
+            target_at = datetime.now(UTC)
+
+        try:
+            result = scrape_jepx_to_rustfs(
+                storage_client=rustfs,
+                scraper=scraper,
+                bucket_name=args.bucket,
+                target_at=target_at,
+            )
+            logger.info(
+                "Uploaded JEPX raw file to s3://%s/%s (%s bytes)",
+                result.bucket_name,
+                result.object_key,
+                result.size_bytes,
+            )
+        finally:
+            scraper.close()
 
 
 if __name__ == "__main__":

--- a/src/pipeline/scraper/jepx_to_rustfs.py
+++ b/src/pipeline/scraper/jepx_to_rustfs.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from core.storage_client import RustFSClient
+from pipeline.scraper.module.jepx import JEPXSpotSummaryScraper
+
+
+@dataclass(frozen=True)
+class JEPXScrapeUploadResult:
+    bucket_name: str
+    object_key: str
+    file_name: str
+    size_bytes: int
+
+
+def scrape_jepx_to_rustfs(
+    storage_client: RustFSClient,
+    scraper: JEPXSpotSummaryScraper,
+    bucket_name: str,
+    target_at: datetime | None = None,
+) -> JEPXScrapeUploadResult:
+    target_at = target_at or datetime.now(UTC)
+    scraped = scraper.scrape(target_at)
+
+    storage_client.upload_bytes(
+        bucket_name=bucket_name,
+        object_name=scraped.object_key,
+        body=scraped.body,
+        content_type=scraped.content_type,
+    )
+
+    return JEPXScrapeUploadResult(
+        bucket_name=bucket_name,
+        object_key=scraped.object_key,
+        file_name=scraped.file_name,
+        size_bytes=len(scraped.body),
+    )

--- a/src/pipeline/scraper/main.py
+++ b/src/pipeline/scraper/main.py
@@ -1,0 +1,59 @@
+import argparse
+import logging
+from datetime import UTC, datetime
+
+from core.storage_client import RustFSClient
+from pipeline.scraper.jepx_to_rustfs import scrape_jepx_to_rustfs
+from pipeline.scraper.module.jepx import JEPXSpotSummaryScraper
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Scrape JEPX spot summary and upload to RustFS"
+    )
+    parser.add_argument(
+        "--bucket",
+        default="jp-power-grid-dev",
+        help="Target bucket name (default: jp-power-grid-dev)",
+    )
+    parser.add_argument(
+        "--timestamp-ms",
+        type=int,
+        help="Optional UNIX timestamp in milliseconds for the JEPX request",
+    )
+    args = parser.parse_args()
+
+    if args.timestamp_ms:
+        target_at = datetime.fromtimestamp(
+            args.timestamp_ms / 1000,
+            tz=UTC,
+        )
+    else:
+        target_at = datetime.now(UTC)
+
+    rustfs = RustFSClient()
+    scraper = JEPXSpotSummaryScraper()
+    try:
+        result = scrape_jepx_to_rustfs(
+            storage_client=rustfs,
+            scraper=scraper,
+            bucket_name=args.bucket,
+            target_at=target_at,
+        )
+        logger.info(
+            "Uploaded JEPX raw file to s3://%s/%s (%s bytes)",
+            result.bucket_name,
+            result.object_key,
+            result.size_bytes,
+        )
+    finally:
+        scraper.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pipeline/scraper/module/base.py
+++ b/src/pipeline/scraper/module/base.py
@@ -1,14 +1,54 @@
-class BaseScraper:
-    def fetch(self):
-        raise NotImplementedError
+from __future__ import annotations
 
-    def parse(self, raw):
-        raise NotImplementedError
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
 
-    def save(self, data):
-        raise NotImplementedError
+import requests
 
-    def run(self):
-        raw = self.fetch()
-        data = self.parse(raw)
-        self.save(data)
+
+@dataclass(frozen=True)
+class RequestSpec:
+    method: str
+    url: str
+    headers: dict[str, str] | None = None
+    params: dict[str, Any] | None = None
+    data: dict[str, Any] | None = None
+
+
+class BaseHttpScraper(ABC):
+    def __init__(
+        self,
+        *,
+        timeout_seconds: int = 30,
+        session: requests.Session | None = None,
+    ) -> None:
+        self.timeout_seconds = timeout_seconds
+        self.session = session or requests.Session()
+
+    @abstractmethod
+    def build_request(self, target_at: datetime) -> RequestSpec:
+        """Build an HTTP request specification for the target time."""
+
+    def fetch(self, target_at: datetime) -> bytes:
+        spec = self.build_request(target_at)
+        response = self.session.request(
+            method=spec.method,
+            url=spec.url,
+            headers=spec.headers,
+            params=spec.params,
+            data=spec.data,
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+        return response.content
+
+    def close(self) -> None:
+        self.session.close()
+
+    def __enter__(self) -> BaseHttpScraper:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()

--- a/src/pipeline/scraper/module/jepx.py
+++ b/src/pipeline/scraper/module/jepx.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from pipeline.scraper.module.base import BaseHttpScraper, RequestSpec
+
+
+@dataclass(frozen=True)
+class JEPXSpotSummaryConfig:
+    base_url: str = "https://www.jepx.jp/_download.php"
+    referer: str = "https://www.jepx.jp/electricpower/market-data/spot/"
+    timeout_seconds: int = 30
+
+
+@dataclass(frozen=True)
+class ScrapedRawObject:
+    object_key: str
+    file_name: str
+    body: bytes
+    content_type: str = "text/csv"
+
+
+class JEPXSpotSummaryScraper(BaseHttpScraper):
+    def __init__(
+        self,
+        config: JEPXSpotSummaryConfig | None = None,
+        session=None,
+    ) -> None:
+        self.config = config or JEPXSpotSummaryConfig()
+        super().__init__(
+            timeout_seconds=self.config.timeout_seconds,
+            session=session,
+        )
+
+    @staticmethod
+    def get_fiscal_year(target_at: datetime) -> int:
+        if target_at.month >= 4:
+            return target_at.year
+        return target_at.year - 1
+
+    @staticmethod
+    def to_timestamp_millis(target_at: datetime) -> int:
+        if target_at.tzinfo is None:
+            target_at = target_at.replace(tzinfo=UTC)
+        return int(target_at.timestamp() * 1000)
+
+    def build_request(self, target_at: datetime) -> RequestSpec:
+        fiscal_year = self.get_fiscal_year(target_at)
+        timestamp_millis = self.to_timestamp_millis(target_at)
+
+        return RequestSpec(
+            method="POST",
+            url=self.config.base_url,
+            params={"timestamp": str(timestamp_millis)},
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Referer": self.config.referer,
+            },
+            data={
+                "dir": "spot_summary",
+                "file": f"spot_summary_{fiscal_year}.csv",
+            },
+        )
+
+    def scrape(self, target_at: datetime) -> ScrapedRawObject:
+        fiscal_year = self.get_fiscal_year(target_at)
+        file_name = f"spot_summary_{fiscal_year}.csv"
+        object_key = f"raw/jepx/spot_summary/{file_name}"
+        body = self.fetch(target_at)
+
+        return ScrapedRawObject(
+            object_key=object_key,
+            file_name=file_name,
+            body=body,
+        )


### PR DESCRIPTION
## Summary
- add reusable HTTP scraper base abstraction for shared scraping logic
- implement JEPX spot summary scraper as source-specific module
- add scrape-to-RustFS pipeline step with dependency injection
- add bytes upload API to RustFS client for scraped payloads
- wire scrape-jepx execution flow from orchestrator

## Validation
- uv run ruff check src/core/storage_client.py src/main.py src/pipeline/scraper/main.py src/pipeline/scraper/module/base.py src/pipeline/scraper/jepx_to_rustfs.py src/pipeline/scraper/module/jepx.py
- /home/vscode/.venv/bin/python src/main.py scrape-jepx --bucket jp-power-grid-dev
