### PR TITLE
Add dbt Silver models for JEPX spot price

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ Optional full refresh:
 uv run python src/main.py run-jepx-staging-dbt --full-refresh
 ```
 
+### 6) Build silver layer with DuckDB + dbt
+
+Run JEPX silver models (base, block, area):
+
+```bash
+uv run python src/main.py run-jepx-silver-dbt
+```
+
+Optional full refresh:
+
+```bash
+uv run python src/main.py run-jepx-silver-dbt --full-refresh
+```
+
 ## Bronze Table Schema
 
 JEPX spot price schema is managed from:

--- a/src/dbt/jepx_power/dbt_project.yml
+++ b/src/dbt/jepx_power/dbt_project.yml
@@ -18,3 +18,6 @@ models:
     staging:
       +materialized: table
       +schema: staging
+    silver:
+      +materialized: table
+      +schema: silver

--- a/src/dbt/jepx_power/models/silver/_silver__models.yml
+++ b/src/dbt/jepx_power/models/silver/_silver__models.yml
@@ -1,0 +1,30 @@
+version: 2
+
+models:
+  - name: silver_jepx_spot_price_base
+    description: "Silver base table for JEPX spot price."
+    columns:
+      - name: delivery_datetime
+        tests:
+          - not_null
+
+  - name: silver_jepx_spot_price_block
+    description: "Silver block volume table for JEPX spot price."
+    columns:
+      - name: delivery_datetime
+        tests:
+          - not_null
+
+  - name: silver_jepx_spot_price_area
+    description: "Silver area price table for JEPX spot price created by unpivoting
+      area columns."
+    columns:
+      - name: delivery_datetime
+        tests:
+          - not_null
+      - name: area_name
+        tests:
+          - not_null
+      - name: area_price
+        tests:
+          - not_null

--- a/src/dbt/jepx_power/models/silver/silver_jepx_spot_price_area.sql
+++ b/src/dbt/jepx_power/models/silver/silver_jepx_spot_price_area.sql
@@ -1,0 +1,27 @@
+{{ config(tags=['silver', 'jepx']) }}
+
+with area_unpivoted as (
+    select
+        delivery_datetime,
+        area_price_column,
+        area_price
+    from {{ ref('stg_jepx_spot_price') }}
+    unpivot (
+        area_price for area_price_column in (
+            area_price_hokkaido,
+            area_price_tohoku,
+            area_price_tokyo,
+            area_price_chubu,
+            area_price_hokuriku,
+            area_price_kansai,
+            area_price_chugoku,
+            area_price_shikoku,
+            area_price_kyushu
+        )
+    )
+)
+select
+    delivery_datetime,
+    split_part(area_price_column, '_', 3) as area_name,
+    area_price
+from area_unpivoted

--- a/src/dbt/jepx_power/models/silver/silver_jepx_spot_price_base.sql
+++ b/src/dbt/jepx_power/models/silver/silver_jepx_spot_price_base.sql
@@ -1,0 +1,9 @@
+{{ config(tags=['silver', 'jepx']) }}
+
+select
+    delivery_datetime,
+    selling_bid_volume,
+    purchase_bid_volume,
+    contracted_volume,
+    system_price
+from {{ ref('stg_jepx_spot_price') }}

--- a/src/dbt/jepx_power/models/silver/silver_jepx_spot_price_block.sql
+++ b/src/dbt/jepx_power/models/silver/silver_jepx_spot_price_block.sql
@@ -1,0 +1,9 @@
+{{ config(tags=['silver', 'jepx']) }}
+
+select
+    delivery_datetime,
+    block_selling_bid_volume,
+    block_selling_contracted_volume,
+    block_purchase_bid_volume,
+    block_purchase_contracted_volume
+from {{ ref('stg_jepx_spot_price') }}

--- a/src/main.py
+++ b/src/main.py
@@ -138,6 +138,21 @@ def main():
         help="Run dbt with --full-refresh",
     )
 
+    dbt_silver_parser = subparsers.add_parser(
+        "run-jepx-silver-dbt",
+        help="Run dbt silver models for JEPX using DuckDB",
+    )
+    dbt_silver_parser.add_argument(
+        "--select",
+        default="tag:silver",
+        help="dbt select expression (default: tag:silver)",
+    )
+    dbt_silver_parser.add_argument(
+        "--full-refresh",
+        action="store_true",
+        help="Run dbt with --full-refresh",
+    )
+
     args = parser.parse_args()
 
     if args.command in {None, "bootstrap-storage"}:
@@ -265,6 +280,28 @@ def main():
             dbt_command.append("--full-refresh")
 
         logger.info("Executing dbt staging command: %s", " ".join(dbt_command))
+        subprocess.run(dbt_command, check=True)
+
+    if args.command == "run-jepx-silver-dbt":
+        project_dir = Path("/workspace/src/dbt/jepx_power")
+        profiles_dir = project_dir
+
+        dbt_command = [
+            "uv",
+            "run",
+            "dbt",
+            "run",
+            "--project-dir",
+            str(project_dir),
+            "--profiles-dir",
+            str(profiles_dir),
+            "--select",
+            args.select,
+        ]
+        if args.full_refresh:
+            dbt_command.append("--full-refresh")
+
+        logger.info("Executing dbt silver command: %s", " ".join(dbt_command))
         subprocess.run(dbt_command, check=True)
 
 


### PR DESCRIPTION
## Summary
- add dbt Silver models for JEPX spot price datasets
- add orchestrator command to run Silver dbt models
- update dbt project configuration and README for Silver layer execution

## Changes
- add Silver models for base, block, and area tables
- implement area transformation using UNPIVOT from area_price_* columns
- add model tests for Silver outputs
- add run-jepx-silver-dbt command in the orchestrator
- document Silver build commands

## Validation
- uv run ruff check src/main.py
- uv run python src/main.py run-jepx-silver-dbt --select tag:silver
- uv run dbt test --project-dir /workspace/src/dbt/jepx_power --profiles-dir /workspace/src/dbt/jepx_power --select tag:silver
