### PR TITLE
Add Copilot CLI setup in DevContainer

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,10 +1,5 @@
 {
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
-      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
-    },
     "ghcr.io/dhoeric/features/hadolint:1": {
       "version": "1.0.0",
       "resolved": "ghcr.io/dhoeric/features/hadolint@sha256:993e7e6f14b7f53aafefb081eb8396ea08f3d48aebb23c91fbaa10651ca0a835",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,8 +11,7 @@
     ],
     "workspaceFolder": "/workspace",
     "features": {
-        "ghcr.io/dhoeric/features/hadolint:1": {},
-        "ghcr.io/devcontainers/features/github-cli:1": {}
+        "ghcr.io/dhoeric/features/hadolint:1": {}
     },
     "customizations": {
         "vscode": {
@@ -41,7 +40,7 @@
         "GOOGLE_APPLICATION_CREDENTIALS": "/workspace/.secrets/keita-masui-firstproject-46adeb7731b9.json",
         "EDITOR": "code --wait"
     },
-    "postCreateCommand": "uv lock || true && uv sync --frozen $(for g in $UV_GROUPS; do printf ' --group %s' \"$g\"; done) && git config --global user.name 'Keita Masui' && git config --global user.email 'rfrnndam.tennis365@gmail.com'",
+    "postCreateCommand": "uv lock || true && uv sync --frozen $(for g in $UV_GROUPS; do printf ' --group %s' \"$g\"; done) && git config --global user.name 'Keita Masui' && git config --global user.email 'rfrnndam.tennis365@gmail.com' && (gh copilot -- --help >/dev/null 2>&1 || true)",
     "postStartCommand": "uv run pre-commit install || true",
     "remoteUser": "vscode"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,16 @@ FROM base AS dev
 RUN useradd -m -s /bin/zsh -u 1000 vscode \
     && apt-get update \
     && apt-get install -y --no-install-recommends git curl ca-certificates \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+ENV PATH="/home/vscode/.local/bin:${PATH}"
 USER vscode
 WORKDIR /workspace
 CMD ["sleep", "infinity"]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,21 @@ Primary bucket layout:
 uv sync --all-groups
 ```
 
-3. Ensure `.env` includes S3-compatible credentials and endpoint:
+1. Authenticate GitHub CLI and enable Copilot CLI:
+
+```bash
+gh auth login
+gh auth refresh -h github.com -s copilot
+```
+
+Validation examples:
+
+```bash
+gh copilot -- --help
+gh copilot -p "explain this command" --allow-tool 'shell(uv)'
+```
+
+1. Ensure `.env` includes S3-compatible credentials and endpoint:
 
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`


### PR DESCRIPTION
## Summary
- install GitHub CLI in the DevContainer image
- make Copilot CLI available in the container startup flow
- document authentication and usage in the README

## Testing
- not run

Closes #60